### PR TITLE
Add Tabulate to the list of dependencies.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tableone" %}
-{% set version = "0.6.3" %}
+{% set version = "0.6.4" %}
 {% set sha256 = "ad39b3a6b577803f0ce8c2a7a0ad8ad1c7fa1104eeb682c652edaa58ebe7b2e9" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,7 @@ requirements:
     - numpy
     - scipy
     - statsmodels
+    - tabulate
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tableone" %}
 {% set version = "0.6.4" %}
-{% set sha256 = "4eea67880e5ba9ad7eaa3985e4a14ab6acd7c9e9385a5fb83357403cbae9f9fa" %}
+{% set sha256 = "ad0a79ae8fd44f494be6836b4090cf2fad98e4c07bb65ca20d95482817dd976f" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tableone" %}
 {% set version = "0.6.4" %}
-{% set sha256 = "ad39b3a6b577803f0ce8c2a7a0ad8ad1c7fa1104eeb682c652edaa58ebe7b2e9" %}
+{% set sha256 = "4eea67880e5ba9ad7eaa3985e4a14ab6acd7c9e9385a5fb83357403cbae9f9fa" %}
 
 package:
   name: {{ name|lower }}


### PR DESCRIPTION
Checklist
* [x ] Used a fork of the feedstock to propose changes
* [x ] Bumped the build number (if the version is unchanged)
* [x ] Reset the build number to `0` (if the version changed)
* [? ] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

This change adds the tabulate package to the tableone dependencies (tabulate is a requirement for tableone >=0.6.4). 

<!--
Please add any other relevant info below:
-->

- I have left the build number at 0, because this requirement is associated with a new version of the tableone package. 

- I'm not clear whether re-rendering is necessary. The documentation at https://conda-forge.org/docs/conda_smithy.html#how-to-re-render gives me a 404. Please let me know if any action on this is needed.

- If I understand correctly, "Ensure the license file is being packaged" is okay, because it is already available at: https://github.com/conda-forge/tableone-feedstock/blob/master/LICENSE.txt