### PR TITLE
Add minimum python version to recipe.

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -5,7 +5,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-16.04
+    vmImage: ubuntu-latest
   strategy:
     matrix:
       linux_64_:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,16 +13,16 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
-    - python
+    - python >=3.9
     - pip
 
   run:
-    - python
+    - python >=3.9
     - pandas
     - numpy
     - scipy


### PR DESCRIPTION
https://github.com/conda-forge/tableone-feedstock/pull/37 is failing on conda-forge-linter with the following message: 

```
Hi! This is the friendly automated conda-forge-linting service.

I wanted to let you know that I linted all conda-recipes in your PR (recipe) and found some lint.

Here's what I've got...

For recipe:

noarch: python recipes are required to have a lower bound on the python version. Typically this means putting python >=3.6 in both host and run but you should check upstream for the package's Python compatibility.
```

This pull request is an attempt to fix the issue, by setting a lower bound on the Python version to `python >=3.9`. Also increase the build number as suggested in https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests.