### PR TITLE
tableone v0.8.0 (adds dependency on hatchling)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About tableone
-==============
+About tableone-feedstock
+========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/tableone-feedstock/blob/main/LICENSE.txt)
 
 Home: http://github.com/tompollard/tableone
 
 Package license: MIT
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/tableone-feedstock/blob/main/LICENSE.txt)
 
 Summary: Create Table 1 for research papers in Python
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tableone" %}
-{% set version = "0.7.12" %}
-{% set sha256 = "567300daa4e6902b7ffb5446d5bb85d3a45a4b9e936cda306d9a51b8ecb965c7" %}
+{% set version = "0.8.0" %}
+{% set sha256 = "85472ec914c8c3248de803aa42c71f595a305a65595936bc87b7ce5a7ce87da1" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,8 @@ requirements:
   host:
     - python >=3.9
     - pip
+    - hatchling
+    - setuptools
 
   run:
     - python >=3.9


### PR DESCRIPTION
https://github.com/conda-forge/tableone-feedstock/pull/41 [is failing](https://github.com/conda-forge/tableone-feedstock/pull/41/checks?check_run_id=13154833278) on what looks like a missing dependency on a build tool (Hatchling). This pull request adds the dependency to #41.